### PR TITLE
Correct Fixed types of schema for BigQuery::Standard module

### DIFF
--- a/lib/relationizer/big_query/standard.rb
+++ b/lib/relationizer/big_query/standard.rb
@@ -76,7 +76,7 @@ module Relationizer
       end
 
       def fixed_types(schema, tuples)
-        tuples.transpose.zip(schema.to_a).map { |(values, (_, type))|
+        tuples.transpose.zip(schema.to_a).map { |values, type|
           next type if type
 
           if values.map { |o| o.is_a?(Array) }.all?

--- a/test/big_query_standard_test.rb
+++ b/test/big_query_standard_test.rb
@@ -42,6 +42,11 @@ class BigQueryStandardTest < Test::Unit::TestCase
       [[1], [2], [3]],
       %Q{SELECT id FROM UNNEST(ARRAY<STRUCT<id INT64, ___dummy STRING>>} +
       %Q{[(1, NULL), (2, NULL), (3, NULL)])}
+    ],
+    "Set fixed types" => [
+      { id: nil, ratio: :FLOAT64 },
+      [[1, 1], [2, 3.14]],
+      %Q{SELECT * FROM UNNEST(ARRAY<STRUCT<id INT64, ratio FLOAT64>>[(1, 1), (2, 3.14)])}
     ]
   }
 


### PR DESCRIPTION
### Test Case

```rb
class FixedTypesTest
  include Relationizer::BigQuery::Standard

  def relation
    create_relation_literal(
      { id: nil, ratio: :FLOAT64 },
      [[1, 1], [2, 3.14]]
    )
  end
end
puts FixedTypesTest.new().relation
```

### Before Correct

raised error

```console
/Users/tomo/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/relationizer-0.2.1/lib/relationizer/big_query/standard.rb:71:in `many_candidate_check': Many candidate: INT64, FLOAT64 (Relationizer::BigQuery::Standard::ReasonlessTypeError)
	from /Users/tomo/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/relationizer-0.2.1/lib/relationizer/big_query/standard.rb:94:in `tap'
	from /Users/tomo/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/relationizer-0.2.1/lib/relationizer/big_query/standard.rb:94:in `block in fixed_types'
	from /Users/tomo/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/relationizer-0.2.1/lib/relationizer/big_query/standard.rb:79:in `map'
	from /Users/tomo/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/relationizer-0.2.1/lib/relationizer/big_query/standard.rb:79:in `fixed_types'
	from /Users/tomo/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/relationizer-0.2.1/lib/relationizer/big_query/standard.rb:29:in `create_relation_literal'
	from -:5:in `relation'
	from -:11:in `<main>'
```

### After Correct

```
SELECT * FROM UNNEST(ARRAY<STRUCT<id INT64, ratio FLOAT64>>[(1, 1), (2, 3.14)])
```