### PR TITLE
Fix BOOL type relation for BigQuery::Standard module

### DIFF
--- a/lib/relationizer/big_query/standard.rb
+++ b/lib/relationizer/big_query/standard.rb
@@ -34,7 +34,7 @@ module Relationizer
           tuple.zip(types).
             map { |(col, type)| to_literal(col, type) }.
             join(", ").
-            tap { |t| break "(#{t}#{', NULL' if tuple.one?})" }
+            tap { |t| break "(#{t}#{', NULL' if tuple.length == 1})" }
         }.join(", ").tap { |t| break "[#{t}]"}
 
         select_exp = if schema.one?
@@ -109,9 +109,16 @@ module Relationizer
           obj.map { |e| to_literal(e, t) }.join(', ').tap { |s| break "[#{s}]"}
         when :TIMESTAMP
           %Q{'#{obj.strftime('%Y-%m-%d %H:%M:%S')}'}
-        when :STRING, :DATE, :BOOL
+        when :STRING, :DATE
           obj.to_s.gsub(/'/, "\'").tap do |s|
             break "'#{s}'"
+          end
+        when :BOOL
+          case obj
+          when TrueClass, FalseClass
+            obj
+          else
+            !!obj
           end
         when :FLOAT64
           case obj

--- a/test/big_query_standard_test.rb
+++ b/test/big_query_standard_test.rb
@@ -94,6 +94,23 @@ class BigQueryStandardTest < Test::Unit::TestCase
                        (2, '2000-01-15 17:45:11')])
       SQL
     ],
+    "BOOL column" => [
+      {
+        id: nil,
+        usable: nil
+      },
+      [
+        [1, true],
+        [2, false]
+      ],
+      <<~SQL.to_one_line
+        SELECT *
+          FROM UNNEST(ARRAY<STRUCT<id INT64,
+                                   usable BOOL>>
+                      [(1, true),
+                       (2, false)])
+      SQL
+    ],
     "Single column relation" => [
       { id: nil },
       [
@@ -124,6 +141,23 @@ class BigQueryStandardTest < Test::Unit::TestCase
                                    ratio FLOAT64>>
                       [(1, 1),
                        (2, 3.14)])
+      SQL
+    ],
+    "Set fixed types as BOOL" => [
+      {
+        id: nil,
+        ratio: :BOOL
+      },
+      [
+        [1, 1],
+        [2, false]
+      ],
+      <<~SQL.to_one_line
+        SELECT *
+          FROM UNNEST(ARRAY<STRUCT<id INT64,
+                                   ratio BOOL>>
+                      [(1, true),
+                       (2, false)])
       SQL
     ]
   }


### PR DESCRIPTION
## Test Case

```rb
class BoolClassRelation
  include Relationizer::BigQuery::Standard

  def relation
    create_relation_literal({ id: nil, usable: nil }, [[1, true], [2, false]])
  end

  def relation_fixed
    create_relation_literal({ id: nil, usable: :BOOL }, [[1, 1], [2, -1]])
  end
end

puts BoolClassRelation.new().relation
puts BoolClassRelation.new().relation_fixed
```

## Before Results

```
# This Relation is not valid for BigQuery
SELECT * FROM UNNEST(ARRAY<STRUCT<id INT64, usable BOOL>>[(1, 'true'), (2, 'false', NULL)])
SELECT * FROM UNNEST(ARRAY<STRUCT<id INT64, usable BOOL>>[(1, '1'), (2, '-1')])
```

## Fixed Results

```
SELECT * FROM UNNEST(ARRAY<STRUCT<id INT64, usable BOOL>>[(1, true), (2, false)])
SELECT * FROM UNNEST(ARRAY<STRUCT<id INT64, usable BOOL>>[(1, true), (2, true)])
```