### PR TITLE
Remove some code for unsupported SQL

### DIFF
--- a/lib/rel_lib/relationizer.rb
+++ b/lib/rel_lib/relationizer.rb
@@ -1,6 +1,5 @@
 require "relationizer/version"
 require_relative "./relationizer/postgresql.rb"
-require_relative "./relationizer/big_query/Legacy.rb"
 require_relative "./relationizer/big_query/Standard.rb"
 
 module Relationizer

--- a/lib/relationizer/big_query/legacy.rb
+++ b/lib/relationizer/big_query/legacy.rb
@@ -1,8 +1,0 @@
-module Relationizer
-  module BigQuery
-    module Legacy
-      def create_relation_literal(rows, schema)
-      end
-    end
-  end
-end

--- a/test/big_query_legacy_test.rb
+++ b/test/big_query_legacy_test.rb
@@ -1,8 +1,0 @@
-require 'test-unit'
-require_relative '../lib/relationizer/big_query/legacy.rb'
-
-class BigQueryLegacyTest < Test::Unit::TestCase
-  test "bq legacy" do
-    assert { 1 == 1 }
-  end
-end


### PR DESCRIPTION
Until the end, BigQuery legacy SQL is not supported.