### PR TITLE
Add support NUMERIC data types for BigQuery

### DIFF
--- a/lib/relationizer/big_query.rb
+++ b/lib/relationizer/big_query.rb
@@ -6,7 +6,7 @@ module Relationizer
     class ReasonlessTypeError < StandardError; end
     class TypeNotFoundError < StandardError; end
 
-    KNOWN_TYPES = [:INT64, :FLOAT64, :STRING, :BOOL, :TIMESTAMP, :DATE]
+    KNOWN_TYPES = [:INT64, :FLOAT64, :STRING, :BOOL, :TIMESTAMP, :DATE, :NUMERIC]
 
     DEFAULT_TYPES = -> (obj) {
       case obj
@@ -134,7 +134,7 @@ module Relationizer
         else
           obj
         end
-      when :INT64
+      when :INT64, :NUMERIC
         obj.to_s
       else
         raise "Unknown type: #{type}"

--- a/test/big_query_test.rb
+++ b/test/big_query_test.rb
@@ -160,6 +160,23 @@ class BigQueryTest < Test::Unit::TestCase
                        (2, false)])
       SQL
     ],
+    "Set fixed types as NUMERIC" => [
+      {
+        id: nil,
+        ratio: :NUMERIC
+      },
+      [
+        [1, 1],
+        [2, 1.08]
+      ],
+      <<~SQL.to_one_line
+        SELECT *
+          FROM UNNEST(ARRAY<STRUCT<`id` INT64,
+                                   `ratio` NUMERIC>>
+                      [(1, 1),
+                       (2, 1.08)])
+      SQL
+    ],
     "Empty tuples with types" => [
       {
         id: :INT64,


### PR DESCRIPTION
FYI: `BigDecimal` 型は NUMERIC に割り当てるべきかなと思っているが BigQuery の NUMERIC は Infinity をサポートしてないので FLOAT のままにしている